### PR TITLE
add optional oidc plugin to enable authentication with oidc

### DIFF
--- a/cmd/kbench.go
+++ b/cmd/kbench.go
@@ -35,6 +35,8 @@ import (
 	"k8s.io/client-go/util/homedir"
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	// Uncomment the following line to load the oidc plugin (only required to authenticate with oidc to your kubernetes cluster).
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"sort"
 	"time"
 )


### PR DESCRIPTION
If you are authenticating with oidc to your kubernetes cluster you need to enable the oidc plugin.

Would be nice to add this at least as an optional parameter. Could be also enabled as default to prevent users from running into issues about authentication.