### PR TITLE
Use KUBECONFIG environment variable if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ without specifying the full kbench path, run it with _sudo_.
 ### Run the Benchmark
 
 Once the installation completes, you can start using K-Bench. To run the benchmark, you need to make sure your 
-_~/.kube/config_ file points to a valid and running `Kubernetes` cluster. To verify this, you may install 
+_~/.kube/config_ file or the KUBECONFIG environment variable points to a valid and running `Kubernetes` cluster. To verify this, you may install 
  kubectl (or if you already have it installed) and simply run:
 
 ```

--- a/cmd/kbench.go
+++ b/cmd/kbench.go
@@ -46,7 +46,9 @@ var defaultoutDir = "."
 
 func main() {
 	var kubeconfig *string
-	if home := homedir.HomeDir(); home != "" {
+	if conf, exists := os.LookupEnv("KUBECONFIG"); exists {
+		kubeconfig = &conf
+	} else if home := homedir.HomeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"),
 			"(optional) absolute path to the kubeconfig file")
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds few lines to recognize the KUBECONFIG variable if it's set.

**Which issue(s) this PR fixes**:

Fixes #27 


**Does this PR introduce a user-facing change?**:

None